### PR TITLE
Fix iterate_plan commands API credential error

### DIFF
--- a/.claude/commands/iterate_plan.md
+++ b/.claude/commands/iterate_plan.md
@@ -1,6 +1,5 @@
 ---
 description: Iterate on existing implementation plans with thorough research and updates
-model: opus
 ---
 
 # Iterate Implementation Plan

--- a/.claude/commands/iterate_plan_nt.md
+++ b/.claude/commands/iterate_plan_nt.md
@@ -1,6 +1,5 @@
 ---
 description: Iterate on existing implementation plans with thorough research and updates
-model: opus
 ---
 
 # Iterate Implementation Plan


### PR DESCRIPTION
Removed 'model: opus' from iterate_plan.md and iterate_plan_nt.md frontmatter. The Opus model specification was causing API errors because the credentials are restricted to Claude Code and cannot be used for spawning sub-agents with different models.